### PR TITLE
Reorder structs fields to reduce memory usage

### DIFF
--- a/api.go
+++ b/api.go
@@ -16,11 +16,11 @@ type API interface {
 }
 
 type api struct {
-	app              *fiber.App
-	config           helpers.Config
 	client           Client
 	stream           Stream
 	serviceDiscovery servicediscovery.ServiceDiscovery
+	app              *fiber.App
+	config           helpers.Config
 }
 
 func (s *api) Listen() {

--- a/async_op.go
+++ b/async_op.go
@@ -13,9 +13,9 @@ type AsyncOp interface {
 }
 
 type asyncOp struct {
+	ctx         context.Context
 	signal      chan struct{}
 	wasResolved bool
-	ctx         context.Context
 }
 
 func (m *asyncOp) Reject() {

--- a/checkpoint.go
+++ b/checkpoint.go
@@ -134,7 +134,10 @@ func (s *checkpoint) StopSchedule() {
 		return
 	}
 
-	s.schedule.Stop()
+	if s.schedule != nil {
+		s.schedule.Stop()
+	}
+
 	logger.Debug("stopped checkpoint schedule")
 }
 

--- a/checkpoint.go
+++ b/checkpoint.go
@@ -30,8 +30,8 @@ type checkpointDocumentCheckpoint struct {
 }
 
 type CheckpointDocument struct {
-	Checkpoint checkpointDocumentCheckpoint `json:"checkpoint"`
 	BucketUUID string                       `json:"bucketUuid"`
+	Checkpoint checkpointDocumentCheckpoint `json:"checkpoint"`
 }
 
 func NewEmptyCheckpointDocument(bucketUUID string) CheckpointDocument {
@@ -50,15 +50,15 @@ func NewEmptyCheckpointDocument(bucketUUID string) CheckpointDocument {
 
 type checkpoint struct {
 	observer     Observer
-	vbIds        []uint16
+	metadata     Metadata
 	failoverLogs map[uint16][]gocbcore.FailoverEntry
 	vbSeqNos     map[uint16]gocbcore.VbSeqNoEntry
-	metadata     Metadata
+	schedule     *time.Ticker
 	bucketUUID   string
+	config       helpers.Config
+	vbIds        []uint16
 	saveLock     sync.Mutex
 	loadLock     sync.Mutex
-	schedule     *time.Ticker
-	config       helpers.Config
 }
 
 func (s *checkpoint) Save() {

--- a/dcp.go
+++ b/dcp.go
@@ -22,13 +22,13 @@ type Dcp interface {
 type dcp struct {
 	client           Client
 	metadata         Metadata
-	listener         Listener
 	stream           Stream
-	config           helpers.Config
 	api              API
 	leaderElection   LeaderElection
 	vBucketDiscovery VBucketDiscovery
 	serviceDiscovery servicediscovery.ServiceDiscovery
+	listener         Listener
+	config           helpers.Config
 }
 
 func (s *dcp) Start() {

--- a/helpers/config.go
+++ b/helpers/config.go
@@ -28,15 +28,15 @@ type ConfigAPI struct {
 }
 
 type ConfigMetric struct {
-	Enabled bool   `yaml:"enabled" default:"true"`
 	Path    string `yaml:"path" default:"/metrics"`
+	Enabled bool   `yaml:"enabled" default:"true"`
 }
 
 type ConfigLeaderElection struct {
-	Enabled bool              `yaml:"enabled" default:"false"`
-	Type    string            `yaml:"type"`
 	Config  map[string]string `yaml:"config"`
+	Type    string            `yaml:"type"`
 	RPC     ConfigRPC         `yaml:"rpc"`
+	Enabled bool              `yaml:"enabled" default:"false"`
 }
 
 type ConfigRPC struct {
@@ -53,23 +53,19 @@ type ConfigCheckpoint struct {
 }
 
 type Config struct {
-	Hosts           []string             `yaml:"hosts"`
-	Username        string               `yaml:"username"`
-	Password        string               `yaml:"password"`
-	BucketName      string               `yaml:"bucketName"`
-	ScopeName       string               `yaml:"scopeName" default:"_default"`
-	CollectionNames []string             `yaml:"collectionNames"`
-	MetadataBucket  string               `yaml:"metadataBucket"`
-	Dcp             ConfigDCP            `yaml:"dcp"`
-	API             ConfigAPI            `yaml:"api"`
-	Metric          ConfigMetric         `yaml:"metric"`
-	LeaderElection  ConfigLeaderElection `yaml:"leaderElector"`
-	Logging         ConfigLogging        `yaml:"logging"`
-	Checkpoint      ConfigCheckpoint     `yaml:"checkpoint"`
-}
-
-func (c *Config) IsCollectionModeEnabled() bool {
-	return !(c.ScopeName == DefaultScopeName && len(c.CollectionNames) == 1 && c.CollectionNames[0] == DefaultCollectionName)
+	LeaderElection ConfigLeaderElection `yaml:"leaderElector"`
+	Metric         ConfigMetric         `yaml:"metric"`
+	BucketName     string               `yaml:"bucketName"`
+	ScopeName      string               `yaml:"scopeName" default:"_default"`
+	CollectionName string               `yaml:"collectionName" default:"_default"`
+	MetadataBucket string               `yaml:"metadataBucket"`
+	Password       string               `yaml:"password"`
+	Username       string               `yaml:"username"`
+	Logging        ConfigLogging        `yaml:"logging"`
+	Hosts          []string             `yaml:"hosts"`
+	Checkpoint     ConfigCheckpoint     `yaml:"checkpoint"`
+	Dcp            ConfigDCP            `yaml:"dcp"`
+	API            ConfigAPI            `yaml:"api"`
 }
 
 func Options(opts *config.Options) {
@@ -86,10 +82,6 @@ func applyUnhandledDefaults(_config *Config) {
 
 	if _config.MetadataBucket == "" {
 		_config.MetadataBucket = _config.BucketName
-	}
-
-	if _config.CollectionNames == nil {
-		_config.CollectionNames = []string{"_default"}
 	}
 }
 

--- a/helpers/config.go
+++ b/helpers/config.go
@@ -53,19 +53,23 @@ type ConfigCheckpoint struct {
 }
 
 type Config struct {
-	LeaderElection ConfigLeaderElection `yaml:"leaderElector"`
-	Metric         ConfigMetric         `yaml:"metric"`
-	BucketName     string               `yaml:"bucketName"`
-	ScopeName      string               `yaml:"scopeName" default:"_default"`
-	CollectionName string               `yaml:"collectionName" default:"_default"`
-	MetadataBucket string               `yaml:"metadataBucket"`
-	Password       string               `yaml:"password"`
-	Username       string               `yaml:"username"`
-	Logging        ConfigLogging        `yaml:"logging"`
-	Hosts          []string             `yaml:"hosts"`
-	Checkpoint     ConfigCheckpoint     `yaml:"checkpoint"`
-	Dcp            ConfigDCP            `yaml:"dcp"`
-	API            ConfigAPI            `yaml:"api"`
+	LeaderElection  ConfigLeaderElection `yaml:"leaderElector"`
+	Metric          ConfigMetric         `yaml:"metric"`
+	BucketName      string               `yaml:"bucketName"`
+	ScopeName       string               `yaml:"scopeName" default:"_default"`
+	CollectionNames []string             `yaml:"collectionNames"`
+	MetadataBucket  string               `yaml:"metadataBucket"`
+	Password        string               `yaml:"password"`
+	Username        string               `yaml:"username"`
+	Logging         ConfigLogging        `yaml:"logging"`
+	Hosts           []string             `yaml:"hosts"`
+	Checkpoint      ConfigCheckpoint     `yaml:"checkpoint"`
+	Dcp             ConfigDCP            `yaml:"dcp"`
+	API             ConfigAPI            `yaml:"api"`
+}
+
+func (c *Config) IsCollectionModeEnabled() bool {
+	return !(c.ScopeName == DefaultScopeName && len(c.CollectionNames) == 1 && c.CollectionNames[0] == DefaultCollectionName)
 }
 
 func Options(opts *config.Options) {
@@ -82,6 +86,10 @@ func applyUnhandledDefaults(_config *Config) {
 
 	if _config.MetadataBucket == "" {
 		_config.MetadataBucket = _config.BucketName
+	}
+
+	if _config.CollectionNames == nil {
+		_config.CollectionNames = []string{DefaultCollectionName}
 	}
 }
 

--- a/leader_election.go
+++ b/leader_election.go
@@ -23,17 +23,17 @@ type LeaderElection interface {
 }
 
 type leaderElection struct {
-	config           helpers.ConfigLeaderElection
 	elector          kle.LeaderElector
 	rpcServer        servicediscovery.Server
 	stream           Stream
 	serviceDiscovery servicediscovery.ServiceDiscovery
-	stable           bool
-	initialized      uint32
+	infoHandler      info.Handler
 	stabilityCh      chan bool
 	myIdentity       *identity.Identity
+	config           helpers.ConfigLeaderElection
 	newLeaderLock    sync.Mutex
-	infoHandler      info.Handler
+	initialized      uint32
+	stable           bool
 }
 
 func (l *leaderElection) OnBecomeLeader() {

--- a/servicediscovery/rpc_client.go
+++ b/servicediscovery/rpc_client.go
@@ -24,10 +24,10 @@ type Client interface {
 
 type client struct {
 	client         *pureRpc.Client
-	port           int
-	connected      bool
 	myIdentity     *identity.Identity
 	targetIdentity *identity.Identity
+	port           int
+	connected      bool
 }
 
 func (c *client) connect() error {

--- a/servicediscovery/rpc_server.go
+++ b/servicediscovery/rpc_server.go
@@ -17,15 +17,15 @@ type Server interface {
 }
 
 type server struct {
-	port     int
 	listener net.Listener
 	handler  *Handler
+	port     int
 }
 
 type Handler struct {
-	port             int
-	myIdentity       *identity.Identity
 	serviceDiscovery ServiceDiscovery
+	myIdentity       *identity.Identity
+	port             int
 }
 
 func (rh *Handler) Ping(_ Ping, reply *Pong) error {

--- a/servicediscovery/service.go
+++ b/servicediscovery/service.go
@@ -2,8 +2,8 @@ package servicediscovery
 
 type Service struct {
 	Client   Client
-	IsLeader bool
 	Name     string
+	IsLeader bool
 }
 
 func NewService(client Client, isLeader bool, name string) *Service {

--- a/servicediscovery/service_discovery.go
+++ b/servicediscovery/service_discovery.go
@@ -29,14 +29,14 @@ type ServiceDiscovery interface {
 }
 
 type serviceDiscovery struct {
+	infoHandler         info.Handler
 	leaderService       *Service
 	services            map[string]*Service
 	healthCheckSchedule *time.Ticker
 	rebalanceSchedule   *time.Ticker
 	info                *info.Model
-	infoHandler         info.Handler
-	amILeader           bool
 	servicesLock        *sync.RWMutex
+	amILeader           bool
 }
 
 func (s *serviceDiscovery) Add(service *Service) {

--- a/stream.go
+++ b/stream.go
@@ -22,24 +22,17 @@ type Stream interface {
 }
 
 type stream struct {
-	client     Client
-	Metadata   Metadata
-	checkpoint Checkpoint
-
-	finishedStreams sync.WaitGroup
-
-	listeners []Listener
-
-	streamsLock sync.Mutex
-	streams     map[uint16]*uint16
-
-	config helpers.Config
-
-	observer Observer
-
+	client           Client
+	Metadata         Metadata
+	checkpoint       Checkpoint
+	observer         Observer
 	vBucketDiscovery VBucketDiscovery
-
-	rebalanceTimer *time.Timer
+	streams          map[uint16]*uint16
+	rebalanceTimer   *time.Timer
+	config           helpers.Config
+	listeners        []Listener
+	finishedStreams  sync.WaitGroup
+	streamsLock      sync.Mutex
 }
 
 func (s *stream) listener(event interface{}, err error) {

--- a/vbucket_discovery.go
+++ b/vbucket_discovery.go
@@ -15,10 +15,10 @@ type VBucketDiscovery interface {
 }
 
 type vBucketDiscovery struct {
-	vBucketNumber int
-	config        helpers.ConfigDCPGroupMembership
 	infoHandler   info.Handler
 	membership    membership.Membership
+	config        helpers.ConfigDCPGroupMembership
+	vBucketNumber int
 }
 
 func (s *vBucketDiscovery) Get() []uint16 {


### PR DESCRIPTION
Order of the struct field affect the memory usage for detail information: https://medium.com/@felipedutratine/how-to-organize-the-go-struct-in-order-to-save-memory-c78afcf59ec2

I reorganized the struct fields.