### PR TITLE
feat: change metadata bucket connection buffer size default value fro…

### DIFF
--- a/config/dcp.go
+++ b/config/dcp.go
@@ -189,7 +189,7 @@ func (c *Dcp) getMetadataConnectionBufferSize() uint {
 		return uint(parsedConnectionBufferSize)
 	}
 
-	return 20971520
+	return 5242880 // 5 MB
 }
 
 func (c *Dcp) getMetadataConnectionTimeout() time.Duration {


### PR DESCRIPTION
As a result of metadata bucket connection buffer size tuning, no need to set it as default 20MB. I have changed the default value to 5MB. 